### PR TITLE
Migrate ligato/networkservicemesh to networkservicemesh/networkservicemesh

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Network Service Mesh Site
 =========================
 
 [![Build Status](https://travis-ci.org/ligato/networkservicemesh-site.svg?branch=master)](https://travis-ci.org/ligato/networkservicemesh-site)
-[![GitHub license](https://img.shields.io/badge/license-Apache%20license%202.0-blue.svg)](https://github.com/ligato/networkservicemesh-site/blob/master/LICENSE)
+[![GitHub license](https://img.shields.io/badge/license-Apache%20license%202.0-blue.svg)](https://github.com/networkservicemesh/site/blob/master/LICENSE)
 [![IRC](https://www.irccloud.com/invite-svg?channel=%23networkservicemesh&amp;hostname=irc.freenode.net&amp;port=6697&amp;ssl=1)](http://webchat.freenode.net/?channels=networkservicemesh)
 
 This is the initial Network Service Mesh website. It was created using
@@ -12,7 +12,7 @@ NOTE: The theme has been added as a git submodule, so to ensure this is checked 
 when you clone this repository, run your clone as follows:
 
 ```
-git clone --recurse-submodules https://github.com/ligato/networkservicemesh-site.git
+git clone --recurse-submodules https://github.com/networkservicemesh/site.git
 ```
 
 To quickly install Hugo, follow [this link](https://gohugo.io/getting-started/quick-start/).

--- a/config.toml
+++ b/config.toml
@@ -9,7 +9,7 @@ theme = "airspace-hugo"
   [[menu.header]]
     weight = 1
     name = "GITHUB"
-    url = "https://github.com/ligato/networkservicemesh"
+    url = "https://github.com/networkservicemesh/networkservicemesh"
 
   [[menu.header]]
     weight = 2

--- a/content/community.md
+++ b/content/community.md
@@ -8,10 +8,10 @@ id = "community"
 We encourage discussion on our mailing list and IRC channel and accept pull requests.
 
 ### Developer Resources
-[![Github Repo](https://img.shields.io/badge/Code-GitHub-brightgreen.svg?style=plastic)](https://github.com/ligato/networkservicemesh)
-[![GitHub issues](https://img.shields.io/github/issues/badges/shields.svg?style=plastic)](https://github.com/ligato/networkservicemesh/issues)
+[![Github Repo](https://img.shields.io/badge/Code-GitHub-brightgreen.svg?style=plastic)](https://github.com/networkservicemesh/networkservicemesh)
+[![GitHub issues](https://img.shields.io/github/issues/badges/shields.svg?style=plastic)](https://github.com/networkservicemesh/networkservicemesh/issues)
 [![Build Status](https://travis-ci.org/ligato/networkservicemesh.svg?branch=master)](https://travis-ci.org/ligato/networkservicemesh)
-[![GitHub license](https://img.shields.io/badge/license-Apache%20license%202.0-blue.svg)](https://github.com/ligato/networkservicemesh/blob/master/LICENSE)
+[![GitHub license](https://img.shields.io/badge/license-Apache%20license%202.0-blue.svg)](https://github.com/networkservicemesh/networkservicemesh/blob/master/LICENSE)
 
 ### Weekly Meetings
 [![Weekly Meeting](https://img.shields.io/badge/Weekly%20Meeting%20Minutes-Tue%208am%20PT-blue.svg?style=plastic)](https://docs.google.com/document/d/1C9NKjo0PWNWypROEO9-Y6haw5h9Xmurvl14SXpciz2Y/edit#heading=h.rc9df0a6n3ng)

--- a/content/docs/setup/QUICK-START.md
+++ b/content/docs/setup/QUICK-START.md
@@ -16,7 +16,7 @@ This document will configure two Vagrant boxes in a Kubernetes cluster with a ma
 * [Docker](https://docs.docker.com/install/)
 
 ```bash
-git clone https://github.com/ligato/networkservicemesh && cd networkservicemesh
+git clone https://github.com/networkservicemesh/networkservicemesh && cd networkservicemesh
 ```
 
 ### Build
@@ -40,7 +40,7 @@ make k8s-deploy
 You can configure your Kubernetes client to interact with the cluster directly.
 
 ```bash
-source $GOPATH/src/github.com/ligato/networkservicemesh/scripts/vagrant/env.sh
+source $GOPATH/src/github.com/networkservicemesh/networkservicemesh/scripts/vagrant/env.sh
 kubectl get daemonset nsmd
 ```
 

--- a/content/docs/tasks/BUILD.md
+++ b/content/docs/tasks/BUILD.md
@@ -145,7 +145,7 @@ dumps the logs from the crossconnect-monitor, which has been logging new crossco
 the cluster.
 
 # Regenerating code
-If you change [types.go](https://github.com/ligato/networkservicemesh/blob/master/k8s/pkg/apis/networkservice/v1/types.go) or any of the .proto files you will need to be able to run ```go generate ./...``` to regenerate the code.
+If you change [types.go](https://github.com/networkservicemesh/networkservicemesh/blob/master/k8s/pkg/apis/networkservice/v1/types.go) or any of the .proto files you will need to be able to run ```go generate ./...``` to regenerate the code.
 
 In order to be able to do that you need to have installed:
 
@@ -172,4 +172,4 @@ If you want to run it locally, you need to:
 
 # Canonical source on how to build
 
-The [.circleci/config.yml](https://github.com/ligato/networkservicemesh/blob/master/.circleci/config.yml) file is the canonical source of how to build Network Service Mesh in case this file becomes out of date.
+The [.circleci/config.yml](https://github.com/networkservicemesh/networkservicemesh/blob/master/.circleci/config.yml) file is the canonical source of how to build Network Service Mesh in case this file becomes out of date.

--- a/content/events/kubeconna2018.md
+++ b/content/events/kubeconna2018.md
@@ -53,5 +53,5 @@ Thursday, December 13
   * [Network Service Mesh Intro](https://www.youtube.com/watch?v=YeAKtUFaqQ0)
   * [Network Service Mesh Deep Dive](https://www.youtube.com/watch?v=SGi9LS870rk)
 * [Website](https://www.networkservicemesh.io/)
-* [GitHub](https://github.com/ligato/networkservicemesh)
+* [GitHub](https://github.com/networkservicemesh/networkservicemesh)
 

--- a/content/events/ossna2018.md
+++ b/content/events/ossna2018.md
@@ -14,7 +14,7 @@ Network Service Mesh will be one of the topics of discussion at [Workshop: Cloud
 # Supporting Collateral
 * [Slides](https://docs.google.com/presentation/d/11Tic2FN8nokIU2_0CZTQwtfjptTIdRfsQLA5NPC0u1A/edit#slide=id.g40088b0520_0_1930)
 * [Website](https://www.networkservicemesh.io/)
-* [Code](https://github.com/ligato/networkservicemesh)
+* [Code](https://github.com/networkservicemesh/networkservicemesh)
 
 # Network Service Mesh Happy Hour
 * [ARC Bar at Fairmont Waterfront Hotel](https://www.fairmont.com/waterfront-vancouver/dining/arc-bar/)


### PR DESCRIPTION
We still leave travis-ci references to ligato:

travis-ci.org/ligato/networkservicemesh
travis-ci.org/ligato/networkservicemesh-site

Signed-off-by: Nikolay Nikolaev <nnikolay@vmware.com>