### PR TITLE
Show only one TOC on mobile

### DIFF
--- a/layouts/partials/docs/article.html
+++ b/layouts/partials/docs/article.html
@@ -17,7 +17,9 @@
       </div>
 
       {{ with $toc }}
-      {{ partial "docs/toc.html" . }}
+      <div class="is-hidden-mobile">
+        {{ partial "docs/toc.html" . }}
+      </div>
       {{ end }}
     </div>
   </div>


### PR DESCRIPTION
This PR fixes an issue where two TOCs are shown on mobile, one at the top of a doc and one at the bottom.