### PR TITLE
Fix macOS prerequisites on build page

### DIFF
--- a/content/docs/tasks/build.md
+++ b/content/docs/tasks/build.md
@@ -16,7 +16,7 @@ Tool | Notes
 On a Mac:
 
 ```bash
-brew install dep golang protobuf shellcheck
+brew install dep golang protobuf protoc-gen-go shellcheck
 ```
 {{< /requirement >}}
 


### PR DESCRIPTION
There is a separate Homebrew package for `protoc-gen-go` which doesn't
get pulled in by the rest, but is required in the "generate" phase of the
build.

Signed-off-by: Lori Jakab <lorand.jakab@gmail.com>