### PR TITLE
Fix collapsibility

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -14,17 +14,17 @@ document.addEventListener('DOMContentLoaded', function() {
   let cardToggles = document.getElementsByClassName('card-toggle');
   for (let i = 0; i < cardToggles.length; i++) {
     cardToggles[i].addEventListener('click', e => {
-      for (let j=0;j< e.currentTarget.childNodes.length;j++) {
-        let n = e.currentTarget.childNodes[j]
-        if (n.nodeType != Node.TEXT_NODE &&  n.classList.contains("card-content")) {
+      let n = e.currentTarget
+      while (n=n.nextSibling) {
+        if (n.nodeType != Node.TEXT_NODE && n.classList.contains("card-content")) {
           n.classList.toggle('is-hidden');
         }
       }
     });
     if (cardToggles[i].id == location.hash.substr(1)) {
-      for (let j=0;j< cardToggles[i].childNodes.length;j++) {
-        let n = cardToggles[i].childNodes[j]
-        if (n.nodeType != Node.TEXT_NODE &&  n.classList.contains("card-content")) {
+      let n = cardToggles[i]
+      while (n=n.nextSibling) {
+        if (n.nodeType != Node.TEXT_NODE && n.classList.contains("card-content")) {
           n.classList.toggle('is-hidden');
         }
       }

--- a/layouts/shortcodes/talk.html
+++ b/layouts/shortcodes/talk.html
@@ -2,8 +2,8 @@
 {{ $title     := .Get "title"}}
 
 
-<div id="{{ anchorize $title }}" class="card card-toggle">
-  <header class="card-header">
+<div class="card">
+  <header id="{{ anchorize $title }}" class="card-header card-toggle">
     <a href="#{{ anchorize $title }}" class="card-header-icon">
       <i class="fa fa-link"></i>
     </a>


### PR DESCRIPTION
Right now clicking *anywhere* in the content of an expanded talk collapses the talk.
This PR makes the collapse happen only if you click on the header.