### PR TITLE
Fix hiding of anchor under navbar

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -21,7 +21,7 @@ document.addEventListener('DOMContentLoaded', function() {
         }
       }
     });
-    if (cardToggles[i].id == location.hash.substr(1)) {
+    if (cardToggles[i].parentElement.parentElement.id == location.hash.substr(1)) {
       let n = cardToggles[i]
       while (n=n.nextSibling) {
         if (n.nodeType != Node.TEXT_NODE && n.classList.contains("card-content")) {

--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -89,3 +89,10 @@ $divider-font-size: $size-1
   -webkit-transform: translateY(-2.6rem)
   -ms-transform: translateY(-2.6rem)
   transform: translateY(-2.6rem)
+
+*[id]:before
+  display: block;
+  content: " ";
+  margin-top: -$navbar-height;
+  height: $navbar-height;
+  visibility: hidden;

--- a/layouts/shortcodes/talk.html
+++ b/layouts/shortcodes/talk.html
@@ -1,20 +1,21 @@
 {{ $time      := .Get "time"}}
 {{ $title     := .Get "title"}}
 
-
-<div class="card">
-  <header id="{{ anchorize $title }}" class="card-header card-toggle">
-    <a href="#{{ anchorize $title }}" class="card-header-icon">
-      <i class="fa fa-link"></i>
-    </a>
-    <a class="card-header-title">{{$time}} - {{$title}}</a>
-    <a class="card-header-icon">
-      <i class="fa fa-angle-down"></i>
-    </a>
-  </header>
-  <div class="card-content is-hidden">
-    <div class="content">
-        {{ .Inner | markdownify }}
+<div id="{{ anchorize $title }}">
+  <div class="card">
+    <header class="card-header card-toggle">
+      <a href="#{{ anchorize $title }}" class="card-header-icon">
+        <i class="fa fa-link"></i>
+      </a>
+      <a class="card-header-title">{{$time}} - {{$title}}</a>
+      <a class="card-header-icon">
+        <i class="fa fa-angle-down"></i>
+      </a>
+    </header>
+    <div class="card-content is-hidden">
+      <div class="content">
+          {{ .Inner | markdownify }}
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Right now if you go to a link like:

https://networkservicemesh.io/events/nsmcon2019/#sponsors

The actual anchor is hidden under the navbar.

This fixes that issue for most anchors, but not the anchors to our
NSMCon talks because the anchors are enclosed in an element of type
flex, and so are not rendered as block elements.