### PR TITLE
Fixed typo - missing t in what-it-is.html

### DIFF
--- a/layouts/partials/home/what-it-is.html
+++ b/layouts/partials/home/what-it-is.html
@@ -16,7 +16,7 @@
 
       <div class="column is-9 is-size-5 is-size-6-mobile">
         <p>
-          Network Service Mesh (<strong>NSM</strong>) is he Hybrid/Multi-cloud IP Service Mesh enabling:
+          Network Service Mesh (<strong>NSM</strong>) is the Hybrid/Multi-cloud IP Service Mesh enabling:
         </p>
 
         <br />


### PR DESCRIPTION
Added the missing 't' in "...the Hybrid/Multi-cloud..."