### PR TITLE
Fix shortcodes to work with goldmark

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -5,6 +5,9 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
 
 # Syntax highlighting settings
 [markup]
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true
   [markup.highlight]
     lineNos = true
     lineNumbersInTable = true

--- a/layouts/shortcodes/speaker.html
+++ b/layouts/shortcodes/speaker.html
@@ -5,42 +5,42 @@
 {{ $linkedin := .Get "linkedin"}}
 
 <article class="media">
-  <figure class="media-left">
-    <p class="image is-64x64">
-      {{ if $img }}
-      <img src="{{ $img }}">
-      {{ else }}
-      <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAAABCAQAAADEZGCcAAAADElEQVR42mNkGGAAAAECAALPi3q9AAAAAElFTkSuQmCC">
-      {{end}}
-    </p>
-  </figure>
+<figure class="media-left">
+<p class="image is-64x64">
+{{ if $img }}
+<img src="{{ $img }}">
+{{ else }}
+<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAAABCAQAAADEZGCcAAAADElEQVR42mNkGGAAAAECAALPi3q9AAAAAElFTkSuQmCC">
+{{end}}
+</p>
+</figure>
 
-  <div class="media-content">
-    <div class="content">
-      <p>
-        <strong>{{$name}}</strong>
-        <br>
-        {{ .Inner | markdownify }}
-      </p>
-    </div>
-    <nav class="level is-mobile">
-      <div class="level-left">
-        {{ with $github }}
-        <a class="level-item">
-          <span class="icon is-small"><a href="http://github.com/{{ . }}"><i class="fab fa-github"></i></a></span>
-        </a>
-        {{ end }}
-        {{ with $twitter }}
-          <a class="level-item">
-            <span class="icon is-small"><a href="http://twitter.com/{{ . }}"><i class="fab fa-twitter"></i></a></span>
-          </a>
-        {{ end }}
-        {{ with $linkedin }}
-          <a class="level-item">
-            <span class="icon is-small"><a href="https://linkedin.com/in/{{ . }}"><i class="fab fa-linkedin"></i></a></span>
-          </a>
-        {{ end }}
-      </div>
-    </nav>
-  </div>
+<div class="media-content">
+<div class="content">
+<p>
+<strong>{{$name}}</strong>
+<br>
+{{ .Inner | markdownify }}
+</p>
+</div>
+<nav class="level is-mobile">
+<div class="level-left">
+{{ with $github }}
+<a class="level-item">
+<span class="icon is-small"><a href="http://github.com/{{ . }}"><i class="fab fa-github"></i></a></span>
+</a>
+{{ end }}
+{{ with $twitter }}
+<a class="level-item">
+<span class="icon is-small"><a href="http://twitter.com/{{ . }}"><i class="fab fa-twitter"></i></a></span>
+</a>
+{{ end }}
+{{ with $linkedin }}
+<a class="level-item">
+<span class="icon is-small"><a href="https://linkedin.com/in/{{ . }}"><i class="fab fa-linkedin"></i></a></span>
+</a>
+{{ end }}
+</div>
+</nav>
+</div>
 </article>

--- a/layouts/shortcodes/talk.html
+++ b/layouts/shortcodes/talk.html
@@ -2,20 +2,20 @@
 {{ $title     := .Get "title"}}
 
 <div id="{{ anchorize $title }}">
-  <div class="card">
-    <header class="card-header card-toggle">
-      <a href="#{{ anchorize $title }}" class="card-header-icon">
-        <i class="fa fa-link"></i>
-      </a>
-      <a class="card-header-title"><span class="talktime">{{$time}}</span> - {{$title}}</a>
-      <a class="card-header-icon">
-        <i class="fa fa-angle-down"></i>
-      </a>
-    </header>
-    <div class="card-content is-hidden">
-      <div class="content">
-          {{ .Inner | markdownify }}
-      </div>
-    </div>
-  </div>
+<div class="card">
+<header class="card-header card-toggle">
+<a href="#{{ anchorize $title }}" class="card-header-icon">
+<i class="fa fa-link"></i>
+</a>
+<a class="card-header-title"><span class="talktime">{{$time}}</span> - {{$title}}</a>
+<a class="card-header-icon">
+<i class="fa fa-angle-down"></i>
+</a>
+</header>
+<div class="card-content is-hidden">
+<div class="content">
+{{ .Inner | markdownify }}
+</div>
+</div>
+</div>
 </div>


### PR DESCRIPTION
Hugo switched from blackfriday to goldmark
as its markdown renderer between 0.55 and 0.88.1.

Goldmark is very very very picky about commonmark
and inline html.

First, 'unsafe' had to be enabled so that inline
html would be rendered at all.

Second, technically anything embedded more than 3 spaces
in commonmark can't be inline html, so the indenting had
to be removed from the talk.html and speaker.html shortcodes.

Signed-off-by: Ed Warnicke <hagbard@gmail.com>
