### PR TITLE
Update setup/run link versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@ You will also need to install [Yarn](https://yarnpkg.com/en/).  Easy install ins
 To run the site after cloning (with fast rendering disabled), run the following:
 
 ```
-make server
+make serve
 ```

--- a/content/docs/setup/run.md
+++ b/content/docs/setup/run.md
@@ -8,24 +8,24 @@ Make sure you have the following dependencies to run NSM:
 * A Kubernetes Cluster - good options include:
   * [kind](https://kind.sigs.k8s.io/) - usually the easiest choice.  Run:
     
-    ``` curl -L https://raw.githubusercontent.com/networkservicemesh/integration-k8s-kind/v1.2.0/cluster-config.yaml | kind create cluster --config -```
+    ``` curl -L https://raw.githubusercontent.com/networkservicemesh/integration-k8s-kind/v1.5.0/cluster-config.yaml | kind create cluster --config -```
 
-  * [gke](https://github.com/networkservicemesh/integration-k8s-gke/blob/v1.2.0/README.md)
-  * [azure](https://github.com/networkservicemesh/integration-k8s-aks/blob/v1.2.0/README.md)
-  * [aws](https://github.com/networkservicemesh/integration-k8s-aws/blob/v1.2.0/README.md)
+  * [gke](https://github.com/networkservicemesh/integration-k8s-gke/blob/v1.5.0/README.md)
+  * [azure](https://github.com/networkservicemesh/integration-k8s-aks/blob/v1.5.0/README.md)
+  * [aws](https://github.com/networkservicemesh/integration-k8s-aws/blob/v1.5.0/README.md)
 * [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 
 ## Install Spire
 If you do not already have Spire on your system install Spire
 
-Follow the instructions [in the README.md](https://github.com/networkservicemesh/deployments-k8s/blob/v1.2.0/examples/spire/README.md)
+Follow the instructions [in the README.md](https://github.com/networkservicemesh/deployments-k8s/blob/v1.5.0/examples/spire/README.md)
 
 ## Install NSM
 If you do not already have NSM infrastructure on your system install NSM
 
-Follow the instructions [in the README.md](https://github.com/networkservicemesh/deployments-k8s/blob/v1.2.0/examples/basic/README.md)
+Follow the instructions [in the README.md](https://github.com/networkservicemesh/deployments-k8s/blob/v1.5.0/examples/basic/README.md)
 
 
 # Examples
 
-Try one of the many [examples](https://github.com/networkservicemesh/deployments-k8s/blob/release/v1.2.0/README.md)
+Try one of the many [examples](https://github.com/networkservicemesh/deployments-k8s/blob/release/v1.5.0/README.md)


### PR DESCRIPTION
I just noticed that the examples pointed to NSM v1.2.0 which is pretty old since NSM is evolving quickly. This patch updates the instructions to v1.5.0 which will show NSM in a much better light.

I included a small fix to the README to save the overhead of a full PR cycle for such a small change.
